### PR TITLE
Fix kal'tsit name -> id conversion

### DIFF
--- a/extensions/modules.py
+++ b/extensions/modules.py
@@ -20,7 +20,7 @@ def get_operator_avatar(operator_name):
     with open("./data/operator_ids.json", "r") as f:
         data = json.load(f)
         for operator, _id in data.items():
-            if operator == operator_name.title():
+            if operator.lower() == operator_name.lower():
                 operator_id = _id
     avatar_url = f"https://raw.githubusercontent.com/Aceship/Arknight-Images/main/avatars/{operator_id}.png"
     return avatar_url


### PR DESCRIPTION
Fixes kal'tsit's name not being converted into id correctly by using `lower()` instead of `title()`

`title()` converts `kal'tsit` into `Kal'Tsit` which does not match with `Kal'tsit` in the data